### PR TITLE
Fix g++ compile and case sensitivity issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ snap
 *.d64
 *.srec
 *.elf
+java_grinder.dSYM
+java_grinder

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 #JOBJS=$(shell ls *.java | sed 's/\.java/\.class/')
 
 default:

--- a/api/adc.h
+++ b/api/adc.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _ADC_H
-#define _ADC_H
+#ifndef ADC_H
+#define ADC_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/amiga_.cxx
+++ b/api/amiga_.cxx
@@ -15,7 +15,7 @@
 #include <stdint.h>
 
 #include "JavaClass.h"
-#include "amiga.h"
+#include "amiga_.h"
 
 #define CHECK_FUNC(funct,sig) \
   if (strcmp(#funct#sig, method_name) == 0) \

--- a/api/amiga_.h
+++ b/api/amiga_.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _AMIGA_API_H
-#define _AMIGA_API_H
+#ifndef AMIGA_API_H
+#define AMIGA_API_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/appleiigs_.h
+++ b/api/appleiigs_.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _APPLEIIGS_H
-#define _APPLEIIGS_H
+#ifndef APPLEIIGS_H
+#define APPLEIIGS_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/atari_2600.h
+++ b/api/atari_2600.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _ATARI_2600_H
-#define _ATARI_2600_H
+#ifndef ATARI_2600_H
+#define ATARI_2600_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/c64_sid.h
+++ b/api/c64_sid.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _C64_SID_H
-#define _C64_SID_H
+#ifndef C64_SID_H
+#define C64_SID_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/c64_vic.h
+++ b/api/c64_vic.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _C64_VIC_H
-#define _C64_VIC_H
+#ifndef C64_VIC_H
+#define C64_VIC_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/cpc_.h
+++ b/api/cpc_.h
@@ -11,8 +11,8 @@
  *
  */
  
-#ifndef _CPC_H
-#define _CPC_H
+#ifndef CPC_H
+#define CPC_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/cpu.h
+++ b/api/cpu.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _CPU_H
-#define _CPU_H
+#ifndef CPU_H
+#define CPU_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/draw3d_object.h
+++ b/api/draw3d_object.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _DRAW3D_OBJECT_API_H
-#define _DRAW3D_OBJECT_API_H
+#ifndef DRAW3D_OBJECT_API_H
+#define DRAW3D_OBJECT_API_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/draw3d_texture.h
+++ b/api/draw3d_texture.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _DRAW3D_TEXTURE_API_H
-#define _DRAW3D_TEXTURE_API_H
+#ifndef DRAW3D_TEXTURE_API_H
+#define DRAW3D_TEXTURE_API_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/dsp.h
+++ b/api/dsp.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _DSP_H
-#define _DSP_H
+#ifndef DSP_H
+#define DSP_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/invoke.h
+++ b/api/invoke.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _INVOKE_H
-#define _INVOKE_H
+#ifndef INVOKE_H
+#define INVOKE_H
 
 #include <string>
 

--- a/api/invoke_static.cxx
+++ b/api/invoke_static.cxx
@@ -20,7 +20,7 @@
 #include "invoke.h"
 #include "invoke_static.h"
 #include "adc.h"
-#include "amiga.h"
+#include "amiga_.h"
 #include "appleiigs_.h"
 #include "atari_2600.h"
 #include "c64_sid.h"

--- a/api/invoke_static.h
+++ b/api/invoke_static.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _INVOKE_STATIC_H
-#define _INVOKE_STATIC_H
+#ifndef INVOKE_STATIC_H
+#define INVOKE_STATIC_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/invoke_virtual.h
+++ b/api/invoke_virtual.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _INVOKE_VIRTUAL_H
-#define _INVOKE_VIRTUAL_H
+#ifndef INVOKE_VIRTUAL_H
+#define INVOKE_VIRTUAL_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/ioport.h
+++ b/api/ioport.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _IOPORT_H
-#define _IOPORT_H
+#ifndef IOPORT_H
+#define IOPORT_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/java_lang_string.h
+++ b/api/java_lang_string.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _JAVA_LANG_STRING_H
-#define _JAVA_LANG_STRING_H
+#ifndef JAVA_LANG_STRING_H
+#define JAVA_LANG_STRING_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/java_lang_system.h
+++ b/api/java_lang_system.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _JAVA_LANG_SYSTEM_H
-#define _JAVA_LANG_SYSTEM_H
+#ifndef JAVA_LANG_SYSTEM_H
+#define JAVA_LANG_SYSTEM_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/math_.h
+++ b/api/math_.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _MATH_H
-#define _MATH_H
+#ifndef MATH_H
+#define MATH_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/memory.h
+++ b/api/memory.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _MEMORY_H
-#define _MEMORY_H
+#ifndef MEMORY_H
+#define MEMORY_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/msx_.h
+++ b/api/msx_.h
@@ -14,8 +14,8 @@
  *                  Emiliano Fraga - https://github.com/efraga-msx
  */
 
-#ifndef _MSX_H
-#define _MSX_H
+#ifndef MSX_H
+#define MSX_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/parallella.h
+++ b/api/parallella.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _PARALLELLA_H
-#define _PARALLELLA_H
+#ifndef PARALLELLA_H
+#define PARALLELLA_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/playstation_2.h
+++ b/api/playstation_2.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _PLAYSTATION_2_API_H
-#define _PLAYSTATION_2_API_H
+#ifndef PLAYSTATION_2_API_H
+#define PLAYSTATION_2_API_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/propeller_.h
+++ b/api/propeller_.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _PROPELLER_H
-#define _PROPELLER_H
+#ifndef PROPELLER_H
+#define PROPELLER_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/sega_genesis.h
+++ b/api/sega_genesis.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _SEGA_GENESIS_H
-#define _SEGA_GENESIS_H
+#ifndef SEGA_GENESIS_H
+#define SEGA_GENESIS_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/snes_.h
+++ b/api/snes_.h
@@ -11,8 +11,8 @@
  *
  */
 
-#ifndef _SNES_API_H
-#define _SNES_API_H
+#ifndef SNES_API_H
+#define SNES_API_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/spi.h
+++ b/api/spi.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _SPI_H
-#define _SPI_H
+#ifndef SPI_H
+#define SPI_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/sxb.h
+++ b/api/sxb.h
@@ -11,8 +11,8 @@
  *
  */
 
-#ifndef _SXB_H
-#define _SXB_H
+#ifndef SXB_H
+#define SXB_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/ti84_.h
+++ b/api/ti84_.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _TI84_H
-#define _TI84_H
+#ifndef TI84_H
+#define TI84_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/ti99_.h
+++ b/api/ti99_.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _TI99_H
-#define _TI99_H
+#ifndef TI99_H
+#define TI99_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/timer.h
+++ b/api/timer.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _TIMER_H
-#define _TIMER_H
+#ifndef TIMER_H
+#define TIMER_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/trs80_coco.h
+++ b/api/trs80_coco.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _TRS80_COCO_H
-#define _TRS80_COCO_H
+#ifndef TRS80_COCO_H
+#define TRS80_COCO_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/uart.h
+++ b/api/uart.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _UART_H
-#define _UART_H
+#ifndef UART_H
+#define UART_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/api/watchdog.h
+++ b/api/watchdog.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _WATCHDOG_H
-#define _WATCHDOG_H
+#ifndef WATCHDOG_H
+#define WATCHDOG_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/build/Makefile
+++ b/build/Makefile
@@ -2,14 +2,14 @@ CC?=gcc
 CXX?=g++
 DEBUG=-DDEBUG -g
 INCLUDES=-I../common -I../generator -I../api
-CFLAGS=-Wall -O3 $(DEBUG) $(INCLUDES)
+CFLAGS=-Wall -O3 $(DEBUG) $(INCLUDES) -std=c++0x
 #CFLAGS=-Wall $(DEBUG) $(INCLUDES)
 LDFLAGS=
 VPATH=../generator:../common:../api
 
 API= \
   adc.o \
-  amiga.o \
+  amiga_.o \
   appleiigs_.o \
   atari_2600.o \
   c64_sid.o \
@@ -41,7 +41,7 @@ API= \
   trs80_coco.o \
   uart.o \
   watchdog.o \
-  Math.o
+  MathUtil.o
 
 CPUS= \
   ARM.o \

--- a/common/Compiler.h
+++ b/common/Compiler.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _COMPILER_H
-#define _COMPILER_H
+#ifndef COMPILER_H
+#define COMPILER_H
 
 #include "Generator.h"
 

--- a/common/JavaClass.h
+++ b/common/JavaClass.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _JAVA_CLASS_H
-#define _JAVA_CLASS_H
+#ifndef JAVA_CLASS_H
+#define JAVA_CLASS_H
 
 #include <stdint.h>
 #include <map>

--- a/common/JavaCompiler.cxx
+++ b/common/JavaCompiler.cxx
@@ -157,7 +157,7 @@ int JavaCompiler::find_external_fields(JavaClass *java_class, bool is_parent)
       DEBUG_PRINT("CLASSNAME '%s' field='%s'\n", class_name.c_str(), field_name.c_str());
 
       // If this field / method exists outside of this class...
-      if (class_name == java_class->get_this_class_name())
+      if (class_name != java_class->get_this_class_name())
       {
         // If this reference is to something outside of this class,
         // recursively load this class.

--- a/common/JavaCompiler.h
+++ b/common/JavaCompiler.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _JAVA_COMPILER_H
-#define _JAVA_COMPILER_H
+#ifndef JAVA_COMPILER_H
+#define JAVA_COMPILER_H
 
 #include <map>
 #include <string>

--- a/common/Util.h
+++ b/common/Util.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _UTIL_H
-#define _UTIL_H
+#ifndef UTIL_H
+#define UTIL_H
 
 #include <string>
 

--- a/common/execute_static.h
+++ b/common/execute_static.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _EXECUTE_STATIC_H
-#define _EXECUTE_STATIC_H
+#ifndef EXECUTE_STATIC_H
+#define EXECUTE_STATIC_H
 
 #include "Generator.h"
 #include "JavaClass.h"

--- a/common/fileio.h
+++ b/common/fileio.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _FILEIO_H
-#define _FILEIO_H
+#ifndef FILEIO_H
+#define FILEIO_H
 
 int16_t read_int16(FILE *in);
 int32_t read_int32(FILE *in);

--- a/common/stack.h
+++ b/common/stack.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _STACK_H
-#define _STACK_H
+#ifndef STACK_H
+#define STACK_H
 
 struct _stack
 {

--- a/common/table_java_instr.h
+++ b/common/table_java_instr.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _TABLE_JAVA_INSTR
-#define _TABLE_JAVA_INSTR
+#ifndef TABLE_JAVA_INSTR
+#define TABLE_JAVA_INSTR
 
 #include <stdint.h>
 

--- a/common/version.h
+++ b/common/version.h
@@ -1,5 +1,5 @@
-#ifndef _VERSION_H
-#define _VERSION_H
+#ifndef VERSION_H
+#define VERSION_H
 
 #define VERSION "December 25, 2018"
 

--- a/generator/API_APPLEIIGS.h
+++ b/generator/API_APPLEIIGS.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _API_APPLEIIGS_H
-#define _API_APPLEIIGS_H
+#ifndef API_APPLEIIGS_H
+#define API_APPLEIIGS_H
 
 class API_AppleIIgs
 {

--- a/generator/API_Amiga.h
+++ b/generator/API_Amiga.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _API_AMIGA_H
-#define _API_AMIGA_H
+#ifndef API_AMIGA_H
+#define API_AMIGA_H
 
 class API_Amiga
 {

--- a/generator/API_Atari2600.h
+++ b/generator/API_Atari2600.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _API_ATARI_2600_H
-#define _API_ATARI_2600_H
+#ifndef API_ATARI_2600_H
+#define API_ATARI_2600_H
 
 class API_Atari2600
 {

--- a/generator/API_C64.h
+++ b/generator/API_C64.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _API_C64_H
-#define _API_C64_H
+#ifndef API_C64_H
+#define API_C64_H
 
 class API_C64
 {

--- a/generator/API_CPC.h
+++ b/generator/API_CPC.h
@@ -11,8 +11,8 @@
  *
  */
 
-#ifndef _API_CPC_H
-#define _API_CPC_H
+#ifndef API_CPC_H
+#define API_CPC_H
 class API_CPC
 {
 public:

--- a/generator/API_DSP.h
+++ b/generator/API_DSP.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _API_DSP_H
-#define _API_DSP_H
+#ifndef API_DSP_H
+#define API_DSP_H
 
 class API_DSP
 {

--- a/generator/API_Draw3D.h
+++ b/generator/API_Draw3D.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _API_DRAW_3D_H
-#define _API_DRAW_3D_H
+#ifndef API_DRAW_3D_H
+#define API_DRAW_3D_H
 
 #define DRAW3D_TYPE_POINT equ 0
 #define DRAW3D_TYPE_LINE equ 1

--- a/generator/API_MSX.h
+++ b/generator/API_MSX.h
@@ -14,8 +14,8 @@
  *                  Emiliano Fraga - https://github.com/efraga-msx
  */
 
-#ifndef _API_MSX_H
-#define _API_MSX_H
+#ifndef API_MSX_H
+#define API_MSX_H
 
 class API_MSX
 {

--- a/generator/API_Math.h
+++ b/generator/API_Math.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _API_MATH_H
-#define _API_MATH_H
+#ifndef API_MATH_H
+#define API_MATH_H
 
 class API_Math
 {

--- a/generator/API_Microcontroller.h
+++ b/generator/API_Microcontroller.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _API_MICROCONTROLLER_H
-#define _API_MICROCONTROLLER_H
+#ifndef API_MICROCONTROLLER_H
+#define API_MICROCONTROLLER_H
 
 class API_Microcontroller
 {

--- a/generator/API_Parallella.h
+++ b/generator/API_Parallella.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _API_PARALLELLA_H
-#define _API_PARALLELLA_H
+#ifndef API_PARALLELLA_H
+#define API_PARALLELLA_H
 
 class API_Parallella
 {

--- a/generator/API_Playstation2.h
+++ b/generator/API_Playstation2.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _API_PLAYSTATION2_H
-#define _API_PLAYSTATION2_H
+#ifndef API_PLAYSTATION2_H
+#define API_PLAYSTATION2_H
 
 class API_Playstation2
 {

--- a/generator/API_Propeller.h
+++ b/generator/API_Propeller.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _API_PROPELLER_H
-#define _API_PROPELLER_H
+#ifndef API_PROPELLER_H
+#define API_PROPELLER_H
 
 class API_Propeller
 {

--- a/generator/API_SNES.h
+++ b/generator/API_SNES.h
@@ -11,8 +11,8 @@
  *
  */
 
-#ifndef _API_SNES_H
-#define _API_SNES_H
+#ifndef API_SNES_H
+#define API_SNES_H
 
 class API_SNES
 {

--- a/generator/API_SXB.h
+++ b/generator/API_SXB.h
@@ -11,8 +11,8 @@
  *
  */
 
-#ifndef _API_SXB_H
-#define _API_SXB_H
+#ifndef API_SXB_H
+#define API_SXB_H
 
 class API_SXB
 {

--- a/generator/API_SegaGenesis.h
+++ b/generator/API_SegaGenesis.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _API_SEGA_GENESIS_H
-#define _API_SEGA_GENESIS_H
+#ifndef API_SEGA_GENESIS_H
+#define API_SEGA_GENESIS_H
 
 class API_SegaGenesis
 {

--- a/generator/API_System.h
+++ b/generator/API_System.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _API_SYSTEM_H
-#define _API_SYSTEM_H
+#ifndef API_SYSTEM_H
+#define API_SYSTEM_H
 
 class API_System
 {

--- a/generator/API_TI84.h
+++ b/generator/API_TI84.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _API_TI84_H
-#define _API_TI84_H
+#ifndef API_TI84_H
+#define API_TI84_H
 
 class API_TI84
 {

--- a/generator/API_TI99.h
+++ b/generator/API_TI99.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _API_TI99_H
-#define _API_TI99_H
+#ifndef API_TI99_H
+#define API_TI99_H
 
 class API_TI99
 {

--- a/generator/API_TRS80_Coco.h
+++ b/generator/API_TRS80_Coco.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _API_TRS80_COCO_H
-#define _API_TRS80_COCO_H
+#ifndef API_TRS80_COCO_H
+#define API_TRS80_COCO_H
 
 class API_TRS80_Coco
 {

--- a/generator/ARM.h
+++ b/generator/ARM.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _ARM_H
-#define _ARM_H
+#ifndef ARM_H
+#define ARM_H
 
 #include "Generator.h"
 

--- a/generator/AVR8.h
+++ b/generator/AVR8.h
@@ -11,8 +11,8 @@
  *
  */
 
-#ifndef _AVR8_H
-#define _AVR8_H
+#ifndef AVR8_H
+#define AVR8_H
 
 #include "Generator.h"
 

--- a/generator/Amiga.h
+++ b/generator/Amiga.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _AMIGA_H
-#define _AMIGA_H
+#ifndef AMIGA_H
+#define AMIGA_H
 
 #include "MC68000.h"
 

--- a/generator/AppleIIgs.h
+++ b/generator/AppleIIgs.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _APPLE_II_GS_H
-#define _APPLE_II_GS_H
+#ifndef APPLE_II_GS_H
+#define APPLE_II_GS_H
 
 #include "W65816.h"
 

--- a/generator/Atari2600.h
+++ b/generator/Atari2600.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _ATARI_2600_H
-#define _ATARI_2600_H
+#ifndef ATARI_2600_H
+#define ATARI_2600_H
 
 #include "M6502_8.h"
 

--- a/generator/C64.h
+++ b/generator/C64.h
@@ -11,8 +11,8 @@
  *
  */
 
-#ifndef _C64_H
-#define _C64_H
+#ifndef C64_H
+#define C64_H
 
 #include "M6502.h"
 

--- a/generator/CPC.h
+++ b/generator/CPC.h
@@ -11,8 +11,8 @@
 *
 */
 
-#ifndef _CPC_H
-#define _CPC_H
+#ifndef CPC_H
+#define CPC_H
 
 #include "Z80.h"
 

--- a/generator/DSPIC.h
+++ b/generator/DSPIC.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _DSPIC_H
-#define _DSPIC_H
+#ifndef DSPIC_H
+#define DSPIC_H
 
 #include "Generator.h"
 

--- a/generator/Epiphany.h
+++ b/generator/Epiphany.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _EPIPHANY_H
-#define _EPIPHANY_H
+#ifndef EPIPHANY_H
+#define EPIPHANY_H
 
 #include "Generator.h"
 

--- a/generator/Generator.h
+++ b/generator/Generator.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _GENERATOR_H
-#define _GENERATOR_H
+#ifndef GENERATOR_H
+#define GENERATOR_H
 
 #include <stdio.h>
 #include <stdint.h>

--- a/generator/M6502.h
+++ b/generator/M6502.h
@@ -11,8 +11,8 @@
  *
  */
 
-#ifndef _M6502_H
-#define _M6502_H
+#ifndef M6502_H
+#define M6502_H
 
 #include "Generator.h"
 

--- a/generator/M6502_8.h
+++ b/generator/M6502_8.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _M6502_8_H
-#define _M6502_8_H
+#ifndef M6502_8_H
+#define M6502_8_H
 
 #include "Generator.h"
 

--- a/generator/MC68000.h
+++ b/generator/MC68000.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _MC68000_H
-#define _MC68000_H
+#ifndef MC68000_H
+#define MC68000_H
 
 #include "Generator.h"
 

--- a/generator/MC68020.h
+++ b/generator/MC68020.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _MC68020_H
-#define _MC68020_H
+#ifndef MC68020_H
+#define MC68020_H
 
 #include "MC68000.h"
 

--- a/generator/MC6809.h
+++ b/generator/MC6809.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _MC6809_H
-#define _MC6809_H
+#ifndef MC6809_H
+#define MC6809_H
 
 #include "Generator.h"
 

--- a/generator/MCS51.h
+++ b/generator/MCS51.h
@@ -11,8 +11,8 @@
  *
  */
 
-#ifndef _TEMPLATE_H
-#define _TEMPLATE_H
+#ifndef TEMPLATE_H
+#define TEMPLATE_H
 
 #include "Generator.h"
 

--- a/generator/MIPS32.h
+++ b/generator/MIPS32.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _MIPS32_H
-#define _MIPS32_H
+#ifndef MIPS32_H
+#define MIPS32_H
 
 #include "Generator.h"
 

--- a/generator/MSP430.h
+++ b/generator/MSP430.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _MSP430_H
-#define _MSP430_H
+#ifndef MSP430_H
+#define MSP430_H
 
 #include "Generator.h"
 

--- a/generator/MSP430X.h
+++ b/generator/MSP430X.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _MSP430X_H
-#define _MSP430X_H
+#ifndef MSP430X_H
+#define MSP430X_H
 
 #include "Generator.h"
 #include "MSP430.h"

--- a/generator/MSX.h
+++ b/generator/MSX.h
@@ -14,8 +14,8 @@
  *                  Emiliano Fraga - https://github.com/efraga-msx
  */
 
-#ifndef _MSX_H
-#define _MSX_H
+#ifndef MSX_H
+#define MSX_H
 
 #include "Z80.h"
 

--- a/generator/MathUtil.cxx
+++ b/generator/MathUtil.cxx
@@ -13,9 +13,9 @@
 #include <stdlib.h>
 #include <stdint.h>
 
-#include "Math.h"
+#include "MathUtil.h"
 
-void Math::add_sin_table(FILE *out)
+void MathUtil::add_sin_table(FILE *out)
 {
   fprintf(out,
     ".align 32\n"
@@ -150,7 +150,7 @@ void Math::add_sin_table(FILE *out)
     "  dc32 -0.0522, -0.0400, -0.0277, -0.0155,\n\n");
 }
 
-void Math::add_cos_table(FILE *out)
+void MathUtil::add_cos_table(FILE *out)
 {
   fprintf(out,
     ".align 32\n"

--- a/generator/MathUtil.h
+++ b/generator/MathUtil.h
@@ -9,18 +9,19 @@
  *
  */
 
-#ifndef _MATH_H
-#define _MATH_H
 
-class Math
+#ifndef MATHUTIL_H
+#define MATHUTIL_H
+
+class MathUtil
 {
 public:
   static void add_sin_table(FILE *out);
   static void add_cos_table(FILE *out);
 
 private:
-  Math() { }
-  ~Math() { }
+  MathUtil() { }
+  ~MathUtil() { }
 };
 
 #endif

--- a/generator/PIC32.h
+++ b/generator/PIC32.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _PIC32_H
-#define _PIC32_H
+#ifndef PIC32_H
+#define PIC32_H
 
 #include "MIPS32.h"
 

--- a/generator/Playstation2.cxx
+++ b/generator/Playstation2.cxx
@@ -14,7 +14,7 @@
 #include <string.h>
 #include <stdint.h>
 
-#include "Math.h"
+#include "MathUtil.h"
 #include "Playstation2.h"
 
 //#define USE_SPU2_DMA
@@ -85,8 +85,8 @@ Playstation2::~Playstation2()
   add_vu0_code();
   add_vu1_code();
   add_strings();
-  Math::add_sin_table(out);
-  Math::add_cos_table(out);
+  MathUtil::add_sin_table(out);
+  MathUtil::add_cos_table(out);
 }
 
 int Playstation2::open(const char *filename)

--- a/generator/Playstation2.h
+++ b/generator/Playstation2.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _PLAYSTATION_2_H
-#define _PLAYSTATION_2_H
+#ifndef PLAYSTATION_2_H
+#define PLAYSTATION_2_H
 
 #include "R5900.h"
 

--- a/generator/Propeller.h
+++ b/generator/Propeller.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _PROPELLER_H
-#define _PROPELLER_H
+#ifndef PROPELLER_H
+#define PROPELLER_H
 
 #include <vector>
 #include <string>

--- a/generator/R5900.h
+++ b/generator/R5900.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _R5900_H
-#define _R5900_H
+#ifndef R5900_H
+#define R5900_H
 
 #include "Generator.h"
 

--- a/generator/SNES.h
+++ b/generator/SNES.h
@@ -11,8 +11,8 @@
  *
  */
 
-#ifndef _SNES_H
-#define _SNES_H
+#ifndef SNES_H
+#define SNES_H
 
 #include "W65816.h"
 

--- a/generator/STDC.h
+++ b/generator/STDC.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _STDC_H
-#define _STDC_H
+#ifndef STDC_H
+#define STDC_H
 
 #include "Generator.h"
 

--- a/generator/SegaGenesis.h
+++ b/generator/SegaGenesis.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _SEGA_GENESIS_H
-#define _SEGA_GENESIS_H
+#ifndef SEGA_GENESIS_H
+#define SEGA_GENESIS_H
 
 #include "MC68000.h"
 

--- a/generator/TI84.h
+++ b/generator/TI84.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _TI84_H
-#define _TI84_H
+#ifndef TI84_H
+#define TI84_H
 
 #include "Z80.h"
 

--- a/generator/TI99.h
+++ b/generator/TI99.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _TI99_H
-#define _TI99_H
+#ifndef TI99_H
+#define TI99_H
 
 #include "TMS9900.h"
 

--- a/generator/TMS9900.h
+++ b/generator/TMS9900.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _TMS9900_H
-#define _TMS9900_H
+#ifndef TMS9900_H
+#define TMS9900_H
 
 #include "Generator.h"
 

--- a/generator/TRS80Coco.h
+++ b/generator/TRS80Coco.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _TRS80_COCO_H
-#define _TRS80_COCO_H
+#ifndef TRS80_COCO_H
+#define TRS80_COCO_H
 
 #include "MC6809.h"
 

--- a/generator/Template.h
+++ b/generator/Template.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _TEMPLATE_H
-#define _TEMPLATE_H
+#ifndef TEMPLATE_H
+#define TEMPLATE_H
 
 #include "Generator.h"
 

--- a/generator/W65816.h
+++ b/generator/W65816.h
@@ -11,8 +11,8 @@
  *
  */
 
-#ifndef _W65816_H
-#define _W65816_H
+#ifndef W65816_H
+#define W65816_H
 
 #include "Generator.h"
 

--- a/generator/W65C134SXB.h
+++ b/generator/W65C134SXB.h
@@ -11,8 +11,8 @@
  *
  */
 
-#ifndef _W65C134SXB_H
-#define _W65C134SXB_H
+#ifndef W65C134SXB_H
+#define W65C134SXB_H
 
 #include "M6502.h"
 

--- a/generator/W65C265SXB.h
+++ b/generator/W65C265SXB.h
@@ -11,8 +11,8 @@
  *
  */
 
-#ifndef _W65C265SXB_H
-#define _W65C265SXB_H
+#ifndef W65C265SXB_H
+#define W65C265SXB_H
 
 #include "W65816.h"
 

--- a/generator/X86.h
+++ b/generator/X86.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _X86_H
-#define _X86_H
+#ifndef X86_H
+#define X86_H
 
 #include "Generator.h"
 

--- a/generator/X86_64.h
+++ b/generator/X86_64.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _X86_64_H
-#define _X86_64_H
+#ifndef X86_64_H
+#define X86_64_H
 
 #include "Generator.h"
 

--- a/generator/Z80.h
+++ b/generator/Z80.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef _Z80_H
-#define _Z80_H
+#ifndef Z80_H
+#define Z80_H
 
 #include "Generator.h"
 

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -1,5 +1,5 @@
 
-CFLAGS=-O3 -Wall -I../common -I../api
+CFLAGS=-O3 -Wall -I../common -I../api -std=c++0x
 OBJECTS=../build/Util.o ../build/invoke.o
 
 default:


### PR DESCRIPTION
This pull request enables `java_grinder` to compile under Ubuntu 16.04 using `g++` and fixes issues triggered by case insensitive file systems. Specifically this PR:

* Removes the leading `_` character in the include header guards since g++ uses leading `_` for its system headers.
* Renames `Math.h` to `MathUtils.h`
* Renames `amiga.*` to `amiga_.*` to avoid conflicts with `Amiga.*`
* Adds entries to `.gitignore` to avoid checking in generated binaries
* Fixes an issue that prevented functions from getting included in assembly output