### PR TITLE
Explicitly specify c++11 for Ubuntu g++ compatibility

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -2,7 +2,7 @@ CC?=gcc
 CXX?=g++
 DEBUG=-DDEBUG -g
 INCLUDES=-I..
-CFLAGS=-Wall -O3 $(DEBUG) $(INCLUDES)
+CFLAGS=-Wall -O3 -std=c++11 $(DEBUG) $(INCLUDES)
 #CFLAGS=-Wall $(DEBUG) $(INCLUDES)
 LDFLAGS=
 VPATH=../api:../common:../generator:..

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -1,5 +1,5 @@
 
-CFLAGS=-O3 -Wall -I../common -I../api
+CFLAGS=-O3 -Wall -I../common -I../api -std=c++11
 OBJECTS=../build/Util.o ../build/invoke.o
 
 default:


### PR DESCRIPTION
This PR fixes an issue compiling **java_grinder** under Ubuntu 16.04 with g++ 5.4.0 by explicitly specifying to use the C++ 11 standard. The errors that would otherwise pop up typically look like:

```
../common/JavaCompiler.cxx:510:35: error: 'to_string' is not a member of 'std'
       label = method_name + "_" + std::to_string(jump_to);
```

More information can be found [here](https://stackoverflow.com/questions/12975341/to-string-is-not-a-member-of-std-says-g-mingw).

This PR fixes the final compilation issue with Ubuntu 16.04 and g++ 5.4.0.