### PR TITLE
Fix building without debug

### DIFF
--- a/common/JavaCompiler.cxx
+++ b/common/JavaCompiler.cxx
@@ -2143,10 +2143,12 @@ int JavaCompiler::load_class(const char *filename)
 
   java_class = new JavaClass(in);
 
+#ifdef DEBUG
   if (verbose)
   {
     java_class->print();
   }
+#endif
 
   int external_field_count = find_external_fields(java_class, true);
 


### PR DESCRIPTION
When building with the `-UDEBUG -DNDEBUG` options set, the build fails with this error:
```
/usr/local/bin/ld: common/JavaCompiler.o: in function `JavaCompiler::load_class(char const*)':
JavaCompiler.cxx:(.text+0x7484): undefined reference to `JavaClass::print()'
```
This patch fixes that bug.